### PR TITLE
Add synchronization when setting interrupted field in Thread::interrupt

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -1724,8 +1724,10 @@ public class Thread implements Runnable {
         }
 
         // Setting the interrupt status must be done before reading nioBlocker.
-        interrupted = true;
-        interrupt0();  // inform VM of interrupt
+        synchronized (interruptLock) {
+            interrupted = true;
+            interrupt0();  // inform VM of interrupt
+        }
 
         // thread may be blocked in an I/O operation
         if (this != Thread.currentThread()) {


### PR DESCRIPTION
This patch fixes eclipse-openj9/openj9#19304.
Setting the `interrupted` field to true and calling `interrupt0` in `Thread::interrupt` used to be synchronized via `interruptLock`. An OpenJDK change removed this synchronization which caused a data race on the `interrupted` field with `ReentrantLockTest` leading to intermittent test failures.

This patch adds the `synchronized` block around setting `interrupted` and calling `interrupt0` and eliminates the data race with `ReentrantLockTest`.

Issues: eclipse-openj9/openj9#19304
Signed-off-by: Nathan Henderson <nathan.henderson@ibm.com>

Backport of: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/812