### PR TITLE
aix/jdk/internal/loader/ClassLoaderHelper.java uses upstream version

### DIFF
--- a/src/java.base/aix/classes/jdk/internal/loader/ClassLoaderHelper.java
+++ b/src/java.base/aix/classes/jdk/internal/loader/ClassLoaderHelper.java
@@ -23,11 +23,6 @@
  * questions.
  */
 
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2020, 2024 All Rights Reserved
- * ===========================================================================
- */
 
 package jdk.internal.loader;
 
@@ -48,18 +43,14 @@ class ClassLoaderHelper {
     }
 
     /**
-     * Returns an alternate path name for the given file
-     * such that if the original pathname did not exist, then the
-     * file may be located at the alternate location.
-     * For AIX, this replaces the final .so suffix with .a
+     * AIX implementation of JVM_LoadLibrary handles the alternate path name mapping.
+     * If loading of the given library name with ".so" suffix fails, it will attempt
+     * to load the library of the same name with ".a" suffix as the alternate name.
+     * This method simply returns null.  It could implement the alternate name
+     * converting ".so" with ".a" suffix but redundant.
      */
     static File mapAlternativeName(File lib) {
-        String name = lib.toString();
-        int index = name.lastIndexOf('.');
-        if (index < 0) {
-            return null;
-        }
-        return new File(name.substring(0, index) + ".a");
+        return null;
     }
 
     /**


### PR DESCRIPTION
`aix/jdk/internal/loader/ClassLoaderHelper.java` uses upstream version

Removed OpenJ9 JCL patch.

Backport
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/814

Signed-off-by: Jason Feng <fengj@ca.ibm.com>