### PR TITLE
Disable more DHE related ciphersuites

### DIFF
--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -185,7 +185,7 @@ RestrictedSecurity.NSS.140-2.securerandom.algorithm = PKCS11
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.name = OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.default = false
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.fips = true
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.hash = SHA256:e71c49d65fd291efe75993ccbe6999e6cfb26bf9ef3e8424cb086c7e2a225ce6
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.hash = SHA256:dd19c8f8f2578cf400c11b5c7d003684cba5fc4999ac5c55d2a73099f70f9582
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.number = Certificate #XXX
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.sunsetDate = 2026-09-21
@@ -210,7 +210,11 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.tls.disabledAlgorithms = \
     TLS_DHE_DSS_WITH_AES_256_CBC_SHA256, \
     TLS_DHE_DSS_WITH_AES_256_GCM_SHA384, \
     TLS_DHE_RSA_WITH_AES_128_CBC_SHA, \
+    TLS_DHE_RSA_WITH_AES_128_CBC_SHA256, \
+    TLS_DHE_RSA_WITH_AES_128_GCM_SHA256, \
     TLS_DHE_RSA_WITH_AES_256_CBC_SHA, \
+    TLS_DHE_RSA_WITH_AES_256_CBC_SHA256, \
+    TLS_DHE_RSA_WITH_AES_256_GCM_SHA384, \
     TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, \
     TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA, \
     TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, \


### PR DESCRIPTION
DHE related cipher suites need Diffie-Hellman crypto services. However, those crypto services are not
allowed in strict profile in FIPS140-3.