### PR TITLE
Ensure static fields set during signed jar process

### DIFF
--- a/src/java.base/share/classes/sun/security/jca/Providers.java
+++ b/src/java.base/share/classes/sun/security/jca/Providers.java
@@ -56,14 +56,6 @@ public class Providers {
     // Note volatile immutable object, so no synchronization needed.
     private static volatile ProviderList providerList;
 
-    static {
-        // set providerList to empty list first in case initialization somehow
-        // triggers a getInstance() call (although that should not happen)
-        providerList = ProviderList.EMPTY;
-        providerList = ProviderList.fromSecurityProperties();
-        RestrictedSecurity.checkHashValues();
-    }
-
     private Providers() {
         // empty
     }
@@ -113,6 +105,14 @@ public class Providers {
         "sun.security.ec.SunEC",
         "com.sun.crypto.provider.SunJCE",
     };
+
+    static {
+        // set providerList to empty list first in case initialization somehow
+        // triggers a getInstance() call (although that should not happen)
+        providerList = ProviderList.EMPTY;
+        providerList = ProviderList.fromSecurityProperties();
+        RestrictedSecurity.checkHashValues();
+    }
 
     // Return Sun provider.
     // This method should only be called by


### PR DESCRIPTION
When loading a signed jar file that is on the classpath, such as the bouncy castle signed JCE jar file, it has been observed that the value of `restrictedJarVerificationProviders` and `jarVerificationProviders` are set to `null`. This causes a NullPointerException during the loading process.

This update moves the static declarations of both
`restrictedJarVerificationProviders` and `jarVerificationProviders` to be prior to the method call `RestrictedSecurity.checkHashValues()` since this method call needs both of these fields to be initialized to work correctly.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>
