### PR TITLE
Avoid rebuilding native code headers for OpenJCEPlus

### DIFF
--- a/closed/make/modules/openjceplus/Lib.gmk
+++ b/closed/make/modules/openjceplus/Lib.gmk
@@ -23,13 +23,14 @@ include LibCommon.gmk
 ifeq (true,$(BUILD_OPENJCEPLUS))
 
 # Identify the desired JGSKIT target platform.
-OPENJCEPLUS_BOOT_JDK := $(BOOT_JDK)
+EXPORT_COMPILER_ENV_VARS :=
+OPENJCEPLUS_JDK := $(JDK_OUTPUTDIR)
 OPENJCEPLUS_GSKIT_HOME := $(OPENJCEPLUS_TOPDIR)/ock/jgsk_sdk
+OPENJCEPLUS_HEADER_FILES := $(SUPPORT_OUTPUTDIR)/headers/openjceplus
 OPENJCEPLUS_JCE_CLASSPATH := $(JDK_OUTPUTDIR)/modules/openjceplus:$(JDK_OUTPUTDIR)/modules/java.base
 OPENJCEPLUS_JGSKIT_MAKE := jgskit.mak
 OPENJCEPLUS_JGSKIT_MAKE_PATH := $(OPENJCEPLUS_TOPDIR)/src/main/native
 OPENJCEPLUS_JGSKIT_PLATFORM :=
-OPENJCEPLUS_VS_LIB :=
 
 ifeq ($(call isTargetOs, aix), true)
   OPENJCEPLUS_JGSKIT_PLATFORM := ppc-aix64
@@ -43,12 +44,13 @@ else ifeq ($(call isTargetOs, linux), true)
   endif
 else ifeq ($(call isTargetOs, windows), true)
   ifeq ($(call isTargetCpu, x86_64), true)
-    OPENJCEPLUS_BOOT_JDK := $(call MixedPath,$(OPENJCEPLUS_BOOT_JDK))
+    EXPORT_COMPILER_ENV_VARS := LIB='$(OPENJ9_VS_LIB)'
+    OPENJCEPLUS_JDK := $(call MixedPath,$(OPENJCEPLUS_JDK))
     OPENJCEPLUS_GSKIT_HOME := $(call MixedPath,$(OPENJCEPLUS_GSKIT_HOME))
-    OPENJCEPLUS_JCE_CLASSPATH := "$(call MixedPath,$(JDK_OUTPUTDIR)/modules/openjceplus)\;$(call MixedPath,$(JDK_OUTPUTDIR)/modules/java.base)"
+    OPENJCEPLUS_HEADER_FILES := $(call MixedPath,$(OPENJCEPLUS_HEADER_FILES))
+    OPENJCEPLUS_JCE_CLASSPATH := "$(call MixedPath,$(JDK_OUTPUTDIR)/modules/openjceplus);$(call MixedPath,$(JDK_OUTPUTDIR)/modules/java.base)"
     OPENJCEPLUS_JGSKIT_MAKE := jgskit.win64.mak
     OPENJCEPLUS_JGSKIT_PLATFORM := win64
-    OPENJCEPLUS_VS_LIB := LIB='$(OPENJ9_VS_LIB)'
   endif
 endif
 
@@ -60,13 +62,17 @@ endif # OPENJCEPLUS_JGSKIT_PLATFORM
 
 compile-libs :
 	@$(ECHO) Compiling OpenJCEPlus native code
-	export \
-			$(OPENJCEPLUS_VS_LIB) \
+	$(EXPORT_COMPILER_ENV_VARS) \
+		$(MAKE) \
+			-C $(OPENJCEPLUS_JGSKIT_MAKE_PATH) \
+			-f $(OPENJCEPLUS_JGSKIT_MAKE) \
+			EXTERNAL_HEADERS=true \
 			GSKIT_HOME=$(OPENJCEPLUS_GSKIT_HOME) \
-			JAVA_HOME=$(OPENJCEPLUS_BOOT_JDK) \
+			JAVA_HOME=$(OPENJCEPLUS_JDK) \
 			JCE_CLASSPATH=$(OPENJCEPLUS_JCE_CLASSPATH) \
+			OPENJCEPLUS_HEADER_FILES=$(OPENJCEPLUS_HEADER_FILES) \
 			PLATFORM=$(OPENJCEPLUS_JGSKIT_PLATFORM) \
-		&& $(MAKE) -j1 -C $(OPENJCEPLUS_JGSKIT_MAKE_PATH) -f $(OPENJCEPLUS_JGSKIT_MAKE) all
+			all
 	@$(ECHO) OpenJCEplus compile complete
 
 TARGETS += compile-libs


### PR DESCRIPTION
Some `OpenJCEPlus` headers are already compiled as part of a previous target, so there is no reason to recompile them. Instead an additional variable is passed as part of the make command to indicate that this step can be skipped.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/824

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>