### PR TITLE
Reduce lock contention in Thread.getAndClearInterrupt

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -1799,17 +1799,20 @@ public class Thread implements Runnable {
         if (com.ibm.oti.vm.VM.isJVMInSingleThreadedMode()) {
             return interruptedImpl();
         }
-        synchronized (interruptLock) {
-            boolean oldValue = interrupted;
-            // We may have been interrupted the moment after we read the field,
-            // so only clear the field if we saw that it was set and will return
-            // true; otherwise we could lose an interrupt.
-            if (oldValue) {
-                interrupted = false;
-                clearInterruptEvent();
+        boolean oldValue = interrupted;
+        if (oldValue) {
+            synchronized (interruptLock) {
+                oldValue = interrupted;
+                // We may have been interrupted the moment after we read the field,
+                // so only clear the field if we saw that it was set and will return
+                // true; otherwise we could lose an interrupt.
+                if (oldValue) {
+                    interrupted = false;
+                    clearInterruptEvent();
+                }
             }
-            return oldValue;
         }
+        return oldValue;
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/VirtualThread.java
+++ b/src/java.base/share/classes/java/lang/VirtualThread.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2024 All Rights Reserved
  * ===========================================================================
  */
 package java.lang;
@@ -923,8 +923,11 @@ final class VirtualThread extends BaseVirtualThread {
             notifyJvmtiDisableSuspend(true);
             try {
                 synchronized (interruptLock) {
-                    interrupted = false;
-                    carrierThread.clearInterrupt();
+                    oldValue = interrupted;
+                    if (oldValue) {
+                        interrupted = false;
+                        carrierThread.clearInterrupt();
+                    }
                 }
             } finally {
                 notifyJvmtiDisableSuspend(false);


### PR DESCRIPTION
Lock contention in `Thread.getAndClearInterrupt` is reduced by
acquiring the lock only when the value of the `Thread.interrupted`
field is `true`.

Related: https://github.com/eclipse-openj9/openj9/issues/20414