### PR TITLE
Enable additional Linux/Mac bundling OpenJCEPlus

### DIFF
--- a/closed/make/modules/openjceplus/Copy.gmk
+++ b/closed/make/modules/openjceplus/Copy.gmk
@@ -33,7 +33,7 @@ ifeq (true,$(BUILD_OPENJCEPLUS))
   # Copy OpenJCEPlus native libraries.
   $(eval $(call SetupCopyFiles, OPENJCEPLUS_JGSKIT_LIBS_COPY, \
       SRC := $(OPENJCEPLUS_TOPDIR)/target, \
-      FILES := $(filter %.dll %.so %.x, $(call FindFiles, $(OPENJCEPLUS_TOPDIR)/target)), \
+      FILES := $(filter %.dll %.dylib %.so %.x, $(call FindFiles, $(OPENJCEPLUS_TOPDIR)/target)), \
       FLATTEN := true, \
       DEST := $(LIB_DST_DIR), \
   ))

--- a/closed/make/modules/openjceplus/Lib.gmk
+++ b/closed/make/modules/openjceplus/Lib.gmk
@@ -35,13 +35,22 @@ OPENJCEPLUS_JGSKIT_PLATFORM :=
 ifeq ($(call isTargetOs, aix), true)
   OPENJCEPLUS_JGSKIT_PLATFORM := ppc-aix64
 else ifeq ($(call isTargetOs, linux), true)
-  ifeq ($(call isTargetCpu, ppc64le), true)
+  ifeq ($(call isTargetCpu, aarch64), true)
+    OPENJCEPLUS_JGSKIT_PLATFORM := arm-linux64
+  else ifeq ($(call isTargetCpu, ppc64le), true)
     OPENJCEPLUS_JGSKIT_PLATFORM := ppcle-linux64
   else ifeq ($(call isTargetCpu, s390x), true)
     OPENJCEPLUS_JGSKIT_PLATFORM := s390-linux64
   else ifeq ($(call isTargetCpu, x86_64), true)
     OPENJCEPLUS_JGSKIT_PLATFORM := x86-linux64
   endif
+else ifeq ($(call isTargetOs, macosx), true)
+  ifeq ($(call isTargetCpu, aarch64), true)
+    OPENJCEPLUS_JGSKIT_PLATFORM := aarch64-mac
+  else ifeq ($(call isTargetCpu, x86_64), true)
+    OPENJCEPLUS_JGSKIT_PLATFORM := x86_64-mac
+  endif
+  OPENJCEPLUS_JGSKIT_MAKE := jgskit.mac.mak
 else ifeq ($(call isTargetOs, windows), true)
   ifeq ($(call isTargetCpu, x86_64), true)
     EXPORT_COMPILER_ENV_VARS := LIB='$(OPENJ9_VS_LIB)'


### PR DESCRIPTION
OpenJCEPlus providers are supported on the Mac OS with aarch64 and amd64 architectures. Also on the Linux aarch64. This PR aims to add aarch64-mac, x86_64-mac and Linux aarch64 to platforms bundling OpenJCEPlus.



Backport from https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/888 & https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/896